### PR TITLE
Rewrite deletion code so that entries are actually deleted

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -55,6 +55,7 @@
 	"logentry-oredict-editentry": "$1 edited entry #$15 ($7{{#if:$8|&nbsp;from $8}}). Changes: $4;",
 	"logentry-oredict-createentry": "$1 created entry #$4 ($6{{#if:$7|&nbsp;from $7}}) and assigned it to the $5 tag and set the bits $9.",
 	"logentry-oredict-edittag": "$1 toggled bits $5 on $4.",
+	"logentry-oredict-delete": "$1 deleted entry $15 ($7 from $8 as $6)",
 	"action-editoredict": "edit OreDict entries",
 	"right-editoredict": "Edit entries for the OreDict extension",
 	"action-importoredict": "mass-import OreDict entries",

--- a/special/OreDictEntryManager.php
+++ b/special/OreDictEntryManager.php
@@ -171,7 +171,7 @@ class OreDictEntryManager extends SpecialPage {
 
 		// Delete before any other processing is done.
 		if ($flags & 0x100 && OreDict::checkExists($fItem, $tag, $mod) != 0) {
-			$dbw->delete($tableName, array('entry_id' => $opts->getValue('entry_id')));
+			$dbw->delete('ext_oredict_items', array('entry_id' => $opts->getValue('entry_id')));
 
 			// Start log
 			$logEntry = new ManualLogEntry('oredict', 'delete');

--- a/special/OreDictEntryManager.php
+++ b/special/OreDictEntryManager.php
@@ -171,7 +171,7 @@ class OreDictEntryManager extends SpecialPage {
 
 		// Delete before any other processing is done.
 		if ($flags & 0x100 && OreDict::checkExists($fItem, $tag, $mod) != 0) {
-			$dbw->delete($tableName, $ary);
+			$dbw->delete($tableName, array('entry_id' => $opts->getValue('entry_id')));
 
 			// Start log
 			$logEntry = new ManualLogEntry('oredict', 'delete');

--- a/special/OreDictEntryManager.php
+++ b/special/OreDictEntryManager.php
@@ -24,7 +24,7 @@ class OreDictEntryManager extends SpecialPage {
 		return 'oredict';
 	}
 
-	public function execute($par){
+	public function execute($par) {
 		// Restrict access from unauthorized users
 		$this->checkPermissions();
 
@@ -123,13 +123,15 @@ class OreDictEntryManager extends SpecialPage {
 	private function updateEntry(FormOptions $opts){
 		$dbw = wfGetDB(DB_MASTER);
 		$stuff = $dbw->select('ext_oredict_items', '*', array('entry_id' => $opts->getValue('entry_id')));
-		$result = $dbw->update('ext_oredict_items', array(
+		$ary = array(
 			//'tag_name' => $opts->getValue('tag_name'),
 			'item_name' => $opts->getValue('item_name'),
 			'mod_name' => $opts->getValue('mod_name'),
 			'grid_params' => $opts->getValue('grid_params'),
 			'flags' => $opts->getValue('flags')
-		), array('entry_id' => $opts->getValue('entry_id')));
+		);
+		$tableName = $dbw->tableName('ext_oredict_items');
+		$result = $dbw->update('ext_oredict_items', $ary, array('entry_id' => $opts->getValue('entry_id')));
 
 		if($stuff->numRows() == 0) return;
 		if($result == false) return;
@@ -167,6 +169,21 @@ class OreDictEntryManager extends SpecialPage {
 		}
 		if($diffString == "" || count($diff) == 0) return; // No change
 
+		// Delete before any other processing is done.
+		if ($flags & 0x100 && OreDict::checkExists($fItem, $tag, $mod) != 0) {
+			$dbw->delete($tableName, $ary);
+
+			// Start log
+			$logEntry = new ManualLogEntry('oredict', 'delete');
+			$logEntry->setPerformer($this->getUser());
+			$logEntry->setTarget(Title::newFromText("Entry/$target", NS_SPECIAL));
+			$logEntry->setParameters(array("6::tag" => $tag, "7::item" => $item->item_name, "8::mod" => $item->mod_name, "15::id" => $item->entry_id));
+			$logId = $logEntry->insert();
+			$logEntry->publish($logId);
+			// End log
+			return;
+		}
+
 		// Start log
 		$logEntry = new ManualLogEntry('oredict', 'editentry');
 		$logEntry->setPerformer($this->getUser());
@@ -178,7 +195,6 @@ class OreDictEntryManager extends SpecialPage {
 
 		$toggleFlag = 0xc0 & (intval($opts->getValue('orig_flags')) ^ intval($opts->getValue('flags')));
 		if($toggleFlag){
-			$tableName = $dbw->tableName('ext_oredict_items');
 			$tagName = $dbw->addQuotes($opts->getValue('tag_name'));
 			$entryId = intval($opts->getValue('entry_id'));
 			$dbw->query("UPDATE $tableName SET `flags` = `flags` ^ $toggleFlag WHERE `tag_name` = $tagName AND `entry_id` != $entryId");

--- a/special/OreDictList.php
+++ b/special/OreDictList.php
@@ -108,8 +108,7 @@ class OreDictList extends SpecialPage {
 			$lMod = $result->mod_name;
 			$lParams = $result->grid_params;
 			$lFlags = $result->flags;
-			if($lFlags & 0x100) $table .= "|- class=\"listDeletedEntry\" style=\"color: grey;\"\n";
-			else $table .= "|-\n";
+			$table .= "|-\n";
 			// Check user rights
 			if ($canEdit) {
 				$editLink = "[[Special:OreDictEntryManager/$lId|Edit]]";


### PR DESCRIPTION
Before this pull request, as described in #13, entries were not deleted, but given a flag that set them as disabled. This new code actually deletes the row from the database when that flag is set to them.

I have tested this on a local wiki installation, and have confirmed that it works.

I'm not sure how this will work when installed against the FTB Wiki which has a ton of disabled entries. I have a [list of disabled entries](https://gist.github.com/elifoster/4bec2d785ef06fe5bb88) in case they don't get deleted, need to be updated to get deleted, or whatever else.

This closes #13.